### PR TITLE
Avoid Double Encoding

### DIFF
--- a/app/interactors/passkeys_rails/begin_challenge.rb
+++ b/app/interactors/passkeys_rails/begin_challenge.rb
@@ -28,7 +28,7 @@ module PasskeysRails
     def cookie_data(options)
       {
         username:,
-        challenge: WebAuthn.standard_encoder.encode(options.challenge)
+        challenge: options.challenge
       }
     end
   end


### PR DESCRIPTION
This PR is more of a question because I can't figure out how you make it work.

When creating a challenge, you call the controller action 

`Started POST "/passkeys/challenge"` 

<img width="688" alt="Screenshot 2024-11-29 at 15 54 50" src="https://github.com/user-attachments/assets/8e9866ee-44e4-45bb-b163-be23c206da9f">

[Link](https://github.com/alliedcode/passkeys-rails/blob/v0.3.2/app/controllers/passkeys_rails/passkeys_controller.rb#L6-L19)

For a registration `BeginChallenge`, call `BeginRegistration`.

<img width="953" alt="Screenshot 2024-11-29 at 16 01 59" src="https://github.com/user-attachments/assets/1ebc8509-5012-4b8f-8af5-e4ff2556a301">

[Link](https://github.com/alliedcode/passkeys-rails/blob/v0.3.2/app/interactors/passkeys_rails/begin_registration.rb#L10)

The `WebAuthn::PublicKeyCredential::Options` creates the challenge:

<img width="553" alt="Screenshot 2024-11-29 at 16 02 35" src="https://github.com/user-attachments/assets/b181cfa5-c99a-4eee-b3ff-a137f210102f">

[Link](https://github.com/cedarcode/webauthn-ruby/blob/v3.2.2/lib/webauthn/public_key_credential/options.rb#L34-L36)

and that challenge is returned encoded:

<img width="314" alt="Screenshot 2024-11-29 at 16 03 59" src="https://github.com/user-attachments/assets/cf20be58-e1c4-4c49-ba5e-8bd2a916663d">

[Link](https://github.com/cedarcode/webauthn-ruby/blob/v3.2.2/lib/webauthn/public_key_credential/options.rb#L20-L22)

So why do re-encode it?

<img width="546" alt="Screenshot 2024-11-29 at 16 04 49" src="https://github.com/user-attachments/assets/13719574-7f4e-432f-a65b-cc9f8cd50b29">

[Link](https://github.com/alliedcode/passkeys-rails/blob/v0.3.2/app/interactors/passkeys_rails/begin_challenge.rb#L31)

Removing the double encoding makes it work for me. I can provide a Rails 8 app example.

